### PR TITLE
Feature/not found error middleware

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,7 +3,10 @@ import morgan from "morgan";
 import createDebug from "debug";
 import chalk from "chalk";
 import cors from "cors";
-import { generalError } from "./middlewares/errorMiddlewares/errorMiddlewares.js";
+import {
+  generalError,
+  notFoundError,
+} from "./middlewares/errorMiddlewares/errorMiddlewares.js";
 
 const debug = createDebug("contacts-api:root:server");
 
@@ -27,6 +30,8 @@ app.use(cors(options));
 app.use(express.json());
 
 app.use(morgan("dev"));
+
+app.use(notFoundError);
 
 app.use(generalError);
 

--- a/src/server/middlewares/errorMiddlewares/errorMiddleware.test.ts
+++ b/src/server/middlewares/errorMiddlewares/errorMiddleware.test.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import CustomError from "../../../CustomError/CustomError";
-import { generalError } from "./errorMiddlewares";
+import { generalError, notFoundError } from "./errorMiddlewares";
 
 type CustomResponse = Pick<Response, "status" | "json">;
 
@@ -46,6 +46,22 @@ describe("Given a generalError middleware", () => {
 
       expect(response.status).toHaveBeenCalledWith(statusCode);
       expect(response.json).toHaveBeenCalledWith({ error: publicMessage });
+    });
+  });
+});
+
+describe("Given a notFoundError middleware", () => {
+  describe("When called with a next function", () => {
+    test("Then it should call the received next function with a custom error", () => {
+      const expectedError = new CustomError(404, "Endpoint not found");
+
+      notFoundError(
+        request as Request,
+        response as Response,
+        next as NextFunction
+      );
+
+      expect(next).toHaveBeenCalledWith(expectedError);
     });
   });
 });

--- a/src/server/middlewares/errorMiddlewares/errorMiddlewares.ts
+++ b/src/server/middlewares/errorMiddlewares/errorMiddlewares.ts
@@ -1,10 +1,20 @@
 import type { Request, Response, NextFunction } from "express";
-import type CustomError from "../../../CustomError/CustomError.js";
+import CustomError from "../../../CustomError/CustomError.js";
 import createDebug from "debug";
 
 const debug = createDebug(
   "contacts-api:root:server:middleware:errorMiddlewares"
 );
+
+export const notFoundError = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const error = new CustomError(404, "Endpoint not found");
+
+  next(error);
+};
 
 export const generalError = (
   error: CustomError,


### PR DESCRIPTION
I've added the notFoundError middleware so the server responds with 404 and 'Endpoint not found' when it receives a request to a non-existen endpoint. It includes the test. 